### PR TITLE
GUI: restrict platform selection

### DIFF
--- a/common/gui_options.cpp
+++ b/common/gui_options.cpp
@@ -166,6 +166,12 @@ String parseGameGUIOptions(const String &str) {
 			ii = c_end;
 		}
 	}
+	// Check for Additional Platforms
+	for (int i = 0; i < str.size(); ++i) {
+		if (str[i] == '\x34') {
+			res += String(str[i]) + String(str[i + 1]);
+		}
+	}
 
 	return res;
 }
@@ -177,6 +183,13 @@ const String getGameGUIOptionsDescription(const String &options) {
 		if (options.contains(g_gameOptions[i].option[0]))
 			res += String(g_gameOptions[i].desc) + " ";
 
+	// Check for Additional Platforms
+	for (int i = 0; i < options.size(); ++i) {
+		if (options[i] == '\x34') {
+			res += String(options[i]) + String(options[i + 1]) + " ";
+		}
+	}
+
 	res.trim();
 
 	return res;
@@ -187,5 +200,12 @@ void updateGameGUIOptions(const String &options, const String &langOption) {
 	ConfMan.setAndFlush("guioptions", newOptionString);
 }
 
+const char *concat(const char *x, const char *y) {
+	char *ret = new char[strlen(x) + strlen(y) + 1];
+	ret[0] = '\0';
+	strncat(ret, x, strlen(x));
+	strncat(ret, y, strlen(y));
+	return ret;
+}
 
 } // End of namespace Common

--- a/common/gui_options.cpp
+++ b/common/gui_options.cpp
@@ -200,12 +200,5 @@ void updateGameGUIOptions(const String &options, const String &langOption) {
 	ConfMan.setAndFlush("guioptions", newOptionString);
 }
 
-const char *concat(const char *x, const char *y) {
-	char *ret = new char[strlen(x) + strlen(y) + 1];
-	ret[0] = '\0';
-	strncat(ret, x, strlen(x));
-	strncat(ret, y, strlen(y));
-	return ret;
-}
 
 } // End of namespace Common

--- a/common/gui_options.h
+++ b/common/gui_options.h
@@ -119,7 +119,7 @@
 
 #define GUIO0() (GUIO_NONE)
 #define GUIO1(a) (a)
-#define GUIO2(a, b) (Common::concat(a, b))
+#define GUIO2(a, b) (a b)
 #define GUIO3(a,b,c) (a b c)
 #define GUIO4(a,b,c,d) (a b c d)
 #define GUIO5(a,b,c,d,e) (a b c d e)
@@ -156,8 +156,6 @@ const String getGameGUIOptionsDescription(const String &options);
  * parameter.
  */
 void updateGameGUIOptions(const String &options, const String &langOption);
-
-const char *concat(const char *x, const char *y);
 
 /** @} */
 

--- a/common/gui_options.h
+++ b/common/gui_options.h
@@ -119,7 +119,7 @@
 
 #define GUIO0() (GUIO_NONE)
 #define GUIO1(a) (a)
-#define GUIO2(a,b) (a b)
+#define GUIO2(a, b) (Common::concat(a, b))
 #define GUIO3(a,b,c) (a b c)
 #define GUIO4(a,b,c,d) (a b c d)
 #define GUIO5(a,b,c,d,e) (a b c d e)
@@ -130,6 +130,8 @@
 #define GUIO10(a,b,c,d,e,f,g,h,i,j) (a b c d e f g h i j)
 #define GUIO11(a,b,c,d,e,f,g,h,i,j,k) (a b c d e f g h i j k)
 #define GUIO12(a,b,c,d,e,f,g,h,i,j,k,l) (a b c d e f g h i j k l)
+
+#define GUIO_PLATFORM(a) (Common::getGameGUIOptionsPlatformCode(a))
 
 namespace Common {
 
@@ -154,6 +156,8 @@ const String getGameGUIOptionsDescription(const String &options);
  * parameter.
  */
 void updateGameGUIOptions(const String &options, const String &langOption);
+
+const char *concat(const char *x, const char *y);
 
 /** @} */
 

--- a/common/gui_options.h
+++ b/common/gui_options.h
@@ -119,7 +119,7 @@
 
 #define GUIO0() (GUIO_NONE)
 #define GUIO1(a) (a)
-#define GUIO2(a, b) (a b)
+#define GUIO2(a,b) (a b)
 #define GUIO3(a,b,c) (a b c)
 #define GUIO4(a,b,c,d) (a b c d)
 #define GUIO5(a,b,c,d,e) (a b c d e)

--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -96,6 +96,91 @@ Platform parsePlatform(const String &str) {
 	return kPlatformUnknown;
 }
 
+const char *getGameGUIOptionsPlatformCode(Platform platform) {
+	switch (platform) {
+	case kPlatformDOS:
+		return "\x34\x01";
+	case kPlatformAmiga:
+		return "\x34\x02";
+	case kPlatformAmstradCPC:
+		return "\x34\x03";
+	case kPlatformAtari8Bit:
+		return "\x34\x04";
+	case kPlatformAtariST:
+		return "\x34\x05";
+	case kPlatformMacintosh:
+		return "\x34\x06";
+	case kPlatformFMTowns:
+		return "\x34\x07";
+	case kPlatformWindows:
+		return "\x34\x08";
+	case kPlatformNES:
+		return "\x34\x09";
+	case kPlatformC64:
+		return "\x34\x0A";
+	case kPlatformCoCo:
+		return "\x34\x0B";
+	case kPlatformCoCo3:
+		return "\x34\x0C";
+	case kPlatformLinux:
+		return "\x34\x0D";
+	case kPlatformAcorn:
+		return "\x34\x0E";
+	case kPlatformSegaCD:
+		return "\x34\x0F";
+	case kPlatform3DO:
+		return "\x34\x10";
+	case kPlatformPCEngine:
+		return "\x34\x11";
+	case kPlatformApple2:
+		return "\x34\x12";
+	case kPlatformApple2GS:
+		return "\x34\x13";
+	case kPlatformPC98:
+		return "\x34\x14";
+	case kPlatformWii:
+		return "\x34\x15";
+	case kPlatformPSX:
+		return "\x34\x16";
+	case kPlatformPS2:
+		return "\x34\x17";
+	case kPlatformPS3:
+		return "\x34\x18";
+	case kPlatformXbox:
+		return "\x34\x19";
+	case kPlatformCDi:
+		return "\x34\x1A";
+	case kPlatformIOS:
+		return "\x34\x1B";
+	case kPlatformAndroid:
+		return "\x34\x1C";
+	case kPlatformOS2:
+		return "\x34\x1D";
+	case kPlatformBeOS:
+		return "\x34\x1E";
+	case kPlatformPocketPC:
+		return "\x34\x1F";
+	case kPlatformMegaDrive:
+		return "\x34\x21";
+	case kPlatformSaturn:
+		return "\x34\x22";
+	case kPlatformPippin:
+		return "\x34\x23";
+	case kPlatformMacintoshII:
+		return "\x34\x24";
+	case kPlatformShockwave:
+		return "\x34\x25";
+	case kPlatformZX:
+		return "\x34\x26";
+	case kPlatformTI994:
+		return "\x34\x27";
+	case kPlatformNintendoSwitch:
+		return "\x34\x28";
+	default:
+		return "\x34\x00"; // Unknown
+	}
+}
+
 
 const char *getPlatformCode(Platform id) {
 	const PlatformDescription *l = g_platforms;
@@ -122,6 +207,16 @@ const char *getPlatformDescription(Platform id) {
 			return l->description;
 	}
 	return l->description;
+}
+
+bool checkGameGUIOptionLanguage(Platform plat, const String &str) {
+	if (!str.contains("lang_")) // If no languages are specified
+		return true;
+
+	if (str.contains(getGameGUIOptionsPlatformCode(plat)))
+		return true;
+
+	return false;
 }
 
 List<String> getPlatformList() {

--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -97,88 +97,11 @@ Platform parsePlatform(const String &str) {
 }
 
 const char *getGameGUIOptionsPlatformCode(Platform platform) {
-	switch (platform) {
-	case kPlatformDOS:
-		return "\x34\x01";
-	case kPlatformAmiga:
-		return "\x34\x02";
-	case kPlatformAmstradCPC:
-		return "\x34\x03";
-	case kPlatformAtari8Bit:
-		return "\x34\x04";
-	case kPlatformAtariST:
-		return "\x34\x05";
-	case kPlatformMacintosh:
-		return "\x34\x06";
-	case kPlatformFMTowns:
-		return "\x34\x07";
-	case kPlatformWindows:
-		return "\x34\x08";
-	case kPlatformNES:
-		return "\x34\x09";
-	case kPlatformC64:
-		return "\x34\x0A";
-	case kPlatformCoCo:
-		return "\x34\x0B";
-	case kPlatformCoCo3:
-		return "\x34\x0C";
-	case kPlatformLinux:
-		return "\x34\x0D";
-	case kPlatformAcorn:
-		return "\x34\x0E";
-	case kPlatformSegaCD:
-		return "\x34\x0F";
-	case kPlatform3DO:
-		return "\x34\x10";
-	case kPlatformPCEngine:
-		return "\x34\x11";
-	case kPlatformApple2:
-		return "\x34\x12";
-	case kPlatformApple2GS:
-		return "\x34\x13";
-	case kPlatformPC98:
-		return "\x34\x14";
-	case kPlatformWii:
-		return "\x34\x15";
-	case kPlatformPSX:
-		return "\x34\x16";
-	case kPlatformPS2:
-		return "\x34\x17";
-	case kPlatformPS3:
-		return "\x34\x18";
-	case kPlatformXbox:
-		return "\x34\x19";
-	case kPlatformCDi:
-		return "\x34\x1A";
-	case kPlatformIOS:
-		return "\x34\x1B";
-	case kPlatformAndroid:
-		return "\x34\x1C";
-	case kPlatformOS2:
-		return "\x34\x1D";
-	case kPlatformBeOS:
-		return "\x34\x1E";
-	case kPlatformPocketPC:
-		return "\x34\x1F";
-	case kPlatformMegaDrive:
-		return "\x34\x21";
-	case kPlatformSaturn:
-		return "\x34\x22";
-	case kPlatformPippin:
-		return "\x34\x23";
-	case kPlatformMacintoshII:
-		return "\x34\x24";
-	case kPlatformShockwave:
-		return "\x34\x25";
-	case kPlatformZX:
-		return "\x34\x26";
-	case kPlatformTI994:
-		return "\x34\x27";
-	case kPlatformNintendoSwitch:
-		return "\x34\x28";
-	default:
-		return "\x34\x00"; // Unknown
-	}
+	if (platform == kPlatformUnknown)
+		return "\x34\x7E";
+
+	static const char val[3] = {'\x34', (char)(platform), '\0'};
+	return val;
 }
 
 
@@ -210,7 +133,7 @@ const char *getPlatformDescription(Platform id) {
 }
 
 bool checkGameGUIOptionLanguage(Platform plat, const String &str) {
-	if (!str.contains("lang_")) // If no languages are specified
+	if (!str.contains("\x34")) // If no platforms are specified
 		return true;
 
 	if (str.contains(getGameGUIOptionsPlatformCode(plat)))

--- a/common/platform.cpp
+++ b/common/platform.cpp
@@ -97,11 +97,88 @@ Platform parsePlatform(const String &str) {
 }
 
 const char *getGameGUIOptionsPlatformCode(Platform platform) {
-	if (platform == kPlatformUnknown)
-		return "\x34\x7E";
-
-	static const char val[3] = {'\x34', (char)(platform), '\0'};
-	return val;
+	switch (platform) {
+	case kPlatformDOS:
+		return "\x34\x01";
+	case kPlatformAmiga:
+		return "\x34\x02";
+	case kPlatformAmstradCPC:
+		return "\x34\x03";
+	case kPlatformAtari8Bit:
+		return "\x34\x04";
+	case kPlatformAtariST:
+		return "\x34\x05";
+	case kPlatformMacintosh:
+		return "\x34\x06";
+	case kPlatformFMTowns:
+		return "\x34\x07";
+	case kPlatformWindows:
+		return "\x34\x08";
+	case kPlatformNES:
+		return "\x34\x09";
+	case kPlatformC64:
+		return "\x34\x0A";
+	case kPlatformCoCo:
+		return "\x34\x0B";
+	case kPlatformCoCo3:
+		return "\x34\x0C";
+	case kPlatformLinux:
+		return "\x34\x0D";
+	case kPlatformAcorn:
+		return "\x34\x0E";
+	case kPlatformSegaCD:
+		return "\x34\x0F";
+	case kPlatform3DO:
+		return "\x34\x10";
+	case kPlatformPCEngine:
+		return "\x34\x11";
+	case kPlatformApple2:
+		return "\x34\x12";
+	case kPlatformApple2GS:
+		return "\x34\x13";
+	case kPlatformPC98:
+		return "\x34\x14";
+	case kPlatformWii:
+		return "\x34\x15";
+	case kPlatformPSX:
+		return "\x34\x16";
+	case kPlatformPS2:
+		return "\x34\x17";
+	case kPlatformPS3:
+		return "\x34\x18";
+	case kPlatformXbox:
+		return "\x34\x19";
+	case kPlatformCDi:
+		return "\x34\x1A";
+	case kPlatformIOS:
+		return "\x34\x1B";
+	case kPlatformAndroid:
+		return "\x34\x1C";
+	case kPlatformOS2:
+		return "\x34\x1D";
+	case kPlatformBeOS:
+		return "\x34\x1E";
+	case kPlatformPocketPC:
+		return "\x34\x1F";
+	case kPlatformMegaDrive:
+		return "\x34\x21";
+	case kPlatformSaturn:
+		return "\x34\x22";
+	case kPlatformPippin:
+		return "\x34\x23";
+	case kPlatformMacintoshII:
+		return "\x34\x24";
+	case kPlatformShockwave:
+		return "\x34\x25";
+	case kPlatformZX:
+		return "\x34\x26";
+	case kPlatformTI994:
+		return "\x34\x27";
+	case kPlatformNintendoSwitch:
+		return "\x34\x28";
+	default:
+		return "\x34\x7E"; // Unknown
+	}
 }
 
 
@@ -132,7 +209,7 @@ const char *getPlatformDescription(Platform id) {
 	return l->description;
 }
 
-bool checkGameGUIOptionLanguage(Platform plat, const String &str) {
+bool checkGameGUIOptionPlatform(Platform plat, const String &str) {
 	if (!str.contains("\x34")) // If no platforms are specified
 		return true;
 

--- a/common/platform.h
+++ b/common/platform.h
@@ -104,7 +104,7 @@ extern const char *getPlatformAbbrev(Platform id);
 extern const char *getPlatformDescription(Platform id);
 extern const char *getGameGUIOptionsPlatformCode(Platform platform);
 
-bool checkGameGUIOptionLanguage(Platform plat, const String &str);
+bool checkGameGUIOptionPlatform(Platform plat, const String &str);
 	List<String> getPlatformList();
 
 /** @} */

--- a/common/platform.h
+++ b/common/platform.h
@@ -102,8 +102,10 @@ extern Platform parsePlatform(const String &str);
 extern const char *getPlatformCode(Platform id);
 extern const char *getPlatformAbbrev(Platform id);
 extern const char *getPlatformDescription(Platform id);
+extern const char *getGameGUIOptionsPlatformCode(Platform platform);
 
-List<String> getPlatformList();
+bool checkGameGUIOptionLanguage(Platform plat, const String &str);
+	List<String> getPlatformList();
 
 /** @} */
 

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -210,6 +210,8 @@ DetectedGame AdvancedMetaEngineDetectionBase::toDetectedGame(const ADDetectedGam
 
 	game.setGUIOptions(desc->guiOptions + _guiOptions);
 	game.appendGUIOptions(getGameGUIOptionsDescriptionLanguage(desc->language));
+	game.appendGUIOptions(getGameGUIOptionsPlatformCode(desc->platform));
+
 
 	if (desc->flags & ADGF_ADDENGLISH)
 		game.appendGUIOptions(getGameGUIOptionsDescriptionLanguage(Common::EN_ANY));

--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -49,8 +49,11 @@ namespace Sci {
 static const struct ADGameDescription SciGameDescriptions[] = {
 	// Astro Chicken - English DOS
 	// SCI interpreter version 0.000.453
-	{"astrochicken", "", {{"resource.map", 0, "f3d1be7752d30ba60614533d531e2e98", 474}, {"resource.001", 0, "6fd05926c2199af0af6f72f90d0d7260", 126895}, AD_LISTEND}, Common::EN_ANY, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_STD16_UNDITHER},
-
+		{"astrochicken", "", {
+		{"resource.map", 0, "f3d1be7752d30ba60614533d531e2e98", 474},
+		{"resource.001", 0, "6fd05926c2199af0af6f72f90d0d7260", 126895},
+		AD_LISTEND},
+		Common::EN_ANY, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_STD16_UNDITHER	},
 	// Castle of Dr. Brain - English Amiga (from www.back2roots.org)
 	// Executable scanning reports "1.005.000"
 	// SCI interpreter version 1.000.510

--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -49,11 +49,12 @@ namespace Sci {
 static const struct ADGameDescription SciGameDescriptions[] = {
 	// Astro Chicken - English DOS
 	// SCI interpreter version 0.000.453
-		{"astrochicken", "", {
+	{"astrochicken", "", {
 		{"resource.map", 0, "f3d1be7752d30ba60614533d531e2e98", 474},
 		{"resource.001", 0, "6fd05926c2199af0af6f72f90d0d7260", 126895},
 		AD_LISTEND},
 		Common::EN_ANY, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_STD16_UNDITHER	},
+
 	// Castle of Dr. Brain - English Amiga (from www.back2roots.org)
 	// Executable scanning reports "1.005.000"
 	// SCI interpreter version 1.000.510

--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -49,7 +49,7 @@ namespace Sci {
 static const struct ADGameDescription SciGameDescriptions[] = {
 	// Astro Chicken - English DOS
 	// SCI interpreter version 0.000.453
-	{"astrochicken", "", {{"resource.map", 0, "f3d1be7752d30ba60614533d531e2e98", 474}, {"resource.001", 0, "6fd05926c2199af0af6f72f90d0d7260", 126895}, AD_LISTEND}, Common::EN_ANY, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO2(GUIO_STD16_UNDITHER, GUIO_PLATFORM(Common::kPlatformMacintoshII))},
+	{"astrochicken", "", {{"resource.map", 0, "f3d1be7752d30ba60614533d531e2e98", 474}, {"resource.001", 0, "6fd05926c2199af0af6f72f90d0d7260", 126895}, AD_LISTEND}, Common::EN_ANY, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_STD16_UNDITHER},
 
 	// Castle of Dr. Brain - English Amiga (from www.back2roots.org)
 	// Executable scanning reports "1.005.000"

--- a/engines/sci/detection_tables.h
+++ b/engines/sci/detection_tables.h
@@ -49,11 +49,7 @@ namespace Sci {
 static const struct ADGameDescription SciGameDescriptions[] = {
 	// Astro Chicken - English DOS
 	// SCI interpreter version 0.000.453
-	{"astrochicken", "", {
-		{"resource.map", 0, "f3d1be7752d30ba60614533d531e2e98", 474},
-		{"resource.001", 0, "6fd05926c2199af0af6f72f90d0d7260", 126895},
-		AD_LISTEND},
-		Common::EN_ANY, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO_STD16_UNDITHER	},
+	{"astrochicken", "", {{"resource.map", 0, "f3d1be7752d30ba60614533d531e2e98", 474}, {"resource.001", 0, "6fd05926c2199af0af6f72f90d0d7260", 126895}, AD_LISTEND}, Common::EN_ANY, Common::kPlatformDOS, ADGF_NO_FLAGS, GUIO2(GUIO_STD16_UNDITHER, GUIO_PLATFORM(Common::kPlatformMacintoshII))},
 
 	// Castle of Dr. Brain - English Amiga (from www.back2roots.org)
 	// Executable scanning reports "1.005.000"

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -464,12 +464,17 @@ void EditGameDialog::open() {
 
 	const Common::PlatformDescription *p = Common::g_platforms;
 	const Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", _domain));
+	const Common::String engineid = ConfMan.get("engineid", _domain);
+
 	sel = 0;
 	for (i = 0; p->code; ++p, ++i) {
 		if (platform == p->id)
 			sel = i + 2;
 	}
 	_platformPopUp->setSelected(sel);
+
+	if (engineid != "sci")
+		_platformPopUp->setEnabled(false);
 }
 
 void EditGameDialog::close() {

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -464,7 +464,6 @@ void EditGameDialog::open() {
 
 	const Common::PlatformDescription *p = Common::g_platforms;
 	const Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", _domain));
-	const Common::String engineid = ConfMan.get("engineid", _domain);
 
 	sel = 0;
 	for (i = 0; p->code; ++p, ++i) {
@@ -472,9 +471,6 @@ void EditGameDialog::open() {
 			sel = i + 2;
 	}
 	_platformPopUp->setSelected(sel);
-
-	if (engineid != "sci")
-		_platformPopUp->setEnabled(false);
 }
 
 void EditGameDialog::close() {

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -464,8 +464,7 @@ void EditGameDialog::open() {
 	}
 
 	const Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", _domain));
-	printf_s("%s \n", _guioptionsString.c_str());
-	printf_s("%s \n", _guioptions.c_str());
+
 	if (ConfMan.hasKey("platform", _domain)) {
 		_platformPopUp->setSelectedTag(platform);
 	} else {

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -381,7 +381,7 @@ void EditGameDialog::addGameControls(GuiObject *boss, const Common::String &pref
 	_platformPopUp->appendEntry("");
 	const Common::PlatformDescription *p = Common::g_platforms;
 	for (; p->code; ++p) {
-		if (checkGameGUIOptionLanguage(p->id, _guioptionsString))
+		if (checkGameGUIOptionPlatform(p->id, _guioptionsString))
 			_platformPopUp->appendEntry(p->description, p->id);
 	}
 }

--- a/gui/editgamedialog.cpp
+++ b/gui/editgamedialog.cpp
@@ -381,7 +381,8 @@ void EditGameDialog::addGameControls(GuiObject *boss, const Common::String &pref
 	_platformPopUp->appendEntry("");
 	const Common::PlatformDescription *p = Common::g_platforms;
 	for (; p->code; ++p) {
-		_platformPopUp->appendEntry(p->description, p->id);
+		if (checkGameGUIOptionLanguage(p->id, _guioptionsString))
+			_platformPopUp->appendEntry(p->description, p->id);
 	}
 }
 
@@ -393,7 +394,7 @@ void EditGameDialog::setupGraphicsTab() {
 void EditGameDialog::open() {
 	OptionsDialog::open();
 
-	int sel, i;
+	int i;
 	bool e;
 
 	// En-/disable dialog items depending on whether overrides are active or not.
@@ -462,15 +463,19 @@ void EditGameDialog::open() {
 		_engineOptions->load();
 	}
 
-	const Common::PlatformDescription *p = Common::g_platforms;
 	const Common::Platform platform = Common::parsePlatform(ConfMan.get("platform", _domain));
-
-	sel = 0;
-	for (i = 0; p->code; ++p, ++i) {
-		if (platform == p->id)
-			sel = i + 2;
+	printf_s("%s \n", _guioptionsString.c_str());
+	printf_s("%s \n", _guioptions.c_str());
+	if (ConfMan.hasKey("platform", _domain)) {
+		_platformPopUp->setSelectedTag(platform);
+	} else {
+		_platformPopUp->setSelectedTag((uint32)Common::kPlatformUnknown);
 	}
-	_platformPopUp->setSelected(sel);
+
+	if (_platformPopUp->numEntries() <= 3) { // If only one platform is available
+		_platformPopUpDesc->setEnabled(false);
+		_platformPopUp->setEnabled(false);
+	}
 }
 
 void EditGameDialog::close() {


### PR DESCRIPTION
Added logic for platform detection:

- adds changes to GUIoptions class to check for platforms
- changes in editgamedialog to only view supported platforms for each game
- restricted platform selection for games having only 1 platform